### PR TITLE
[feat/#3] 주문완료 api & 유저 적립금 api 로직 구현

### DIFF
--- a/src/main/java/com/study/kioskbackend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/controller/OrderController.java
@@ -1,0 +1,11 @@
+package com.study.kioskbackend.domain.order.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+
+
+}

--- a/src/main/java/com/study/kioskbackend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/controller/OrderController.java
@@ -1,11 +1,25 @@
 package com.study.kioskbackend.domain.order.controller;
 
+import com.study.kioskbackend.domain.order.dto.OrderRequestDto;
+import com.study.kioskbackend.domain.order.entity.Order;
+import com.study.kioskbackend.domain.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class OrderController {
 
+    private final OrderService orderService;
 
+    @PostMapping("/order")
+    public ResponseEntity<Order> order(@RequestBody OrderRequestDto orderRequestDto) {
+        return orderService.order(orderRequestDto);
+    }
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/controller/OrderController.java
@@ -3,13 +3,9 @@ package com.study.kioskbackend.domain.order.controller;
 import com.study.kioskbackend.domain.order.dto.OrderRequestDto;
 import com.study.kioskbackend.domain.order.entity.Order;
 import com.study.kioskbackend.domain.order.service.OrderService;
+import com.study.kioskbackend.global.common.ResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,7 +15,17 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping("/order")
-    public ResponseEntity<Order> order(@RequestBody OrderRequestDto orderRequestDto) {
+    public ResponseDto<Order> order(@RequestBody OrderRequestDto orderRequestDto) {
         return orderService.order(orderRequestDto);
+    }
+
+    @PatchMapping("/order")
+    public ResponseDto<Void> updateUserPoint(@RequestParam("point") int point) {
+        return orderService.updateUserPoint(point);
+    }
+
+    @GetMapping("/order")
+    public ResponseDto<Integer> getUserPoint() {
+        return orderService.getUserPoint("user1");
     }
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/dto/OrderRequestDto.java
@@ -1,7 +1,7 @@
 package com.study.kioskbackend.domain.order.dto;
 
 import com.study.kioskbackend.domain.order.entity.Order;
-import com.study.kioskbackend.global.common.OrderStatus;
+import com.study.kioskbackend.domain.order.enumeration.OrderStatus;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,7 +16,6 @@ public class OrderRequestDto {
 
     private int totalCount;
     private int totalPrice;
-
 
     public Order toEntity(int orderNumber) {
         return Order.builder()

--- a/src/main/java/com/study/kioskbackend/domain/order/dto/OrderRequestDto.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/dto/OrderRequestDto.java
@@ -1,0 +1,32 @@
+package com.study.kioskbackend.domain.order.dto;
+
+import com.study.kioskbackend.domain.order.entity.Order;
+import com.study.kioskbackend.global.common.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class OrderRequestDto {
+
+    private int totalCount;
+    private int totalPrice;
+
+
+    public Order toEntity(int orderNumber) {
+        return Order.builder()
+                .order_code(UUID.randomUUID().toString())
+                .order_price(totalPrice)
+                .order_count(totalCount)
+                .order_number(orderNumber)
+                .order_status(OrderStatus.결제완료)
+                .order_time(LocalDateTime.now())
+                .is_deleted(false)
+                .build();
+    }
+}

--- a/src/main/java/com/study/kioskbackend/domain/order/entity/Order.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/entity/Order.java
@@ -1,6 +1,6 @@
 package com.study.kioskbackend.domain.order.entity;
 
-import com.study.kioskbackend.global.common.OrderStatus;
+import com.study.kioskbackend.domain.order.enumeration.OrderStatus;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/study/kioskbackend/domain/order/entity/Order.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/entity/Order.java
@@ -1,0 +1,8 @@
+package com.study.kioskbackend.domain.order.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+
+public class Order {
+}

--- a/src/main/java/com/study/kioskbackend/domain/order/entity/Order.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/entity/Order.java
@@ -1,8 +1,39 @@
 package com.study.kioskbackend.domain.order.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.study.kioskbackend.global.common.OrderStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
 
 
+@Entity
+@Table(name = "order_menu")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long order_idx;
+
+    private String order_code;
+
+    private int order_price;
+
+    private int order_count;
+
+    private int order_number;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus order_status;
+
+    private LocalDateTime order_time;
+
+    private LocalDateTime order_update_date;
+
+    private Boolean is_deleted;
+
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/enumeration/OrderStatus.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/enumeration/OrderStatus.java
@@ -1,4 +1,4 @@
-package com.study.kioskbackend.global.common;
+package com.study.kioskbackend.domain.order.enumeration;
 
 public enum OrderStatus {
     결제완료,

--- a/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.study.kioskbackend.domain.order.repository;
+
+import com.study.kioskbackend.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order,Long> {
+}

--- a/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order,Long> {
 
-    @Query(value = "SELECT o.order_number FROM Order o WHERE DATE(o.order_time) = :orderTime ORDER BY o.order_number DESC")
+    @Query(value = "SELECT o.order_number FROM Order o WHERE DATE(o.order_time) = :orderTime ORDER BY o.order_number DESC limit 1")
     Optional<Integer> findLatestOrderNumber(@Param("orderTime") LocalDate orderTime);
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
@@ -2,6 +2,12 @@ package com.study.kioskbackend.domain.order.repository;
 
 import com.study.kioskbackend.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order,Long> {
+
+    @Query(value = "SELECT o.order_number FROM Order o ORDER BY o.order_number DESC")
+    Optional<Integer> findLatestOrderNumber();
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/repository/OrderRepository.java
@@ -3,11 +3,13 @@ package com.study.kioskbackend.domain.order.repository;
 import com.study.kioskbackend.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order,Long> {
 
-    @Query(value = "SELECT o.order_number FROM Order o ORDER BY o.order_number DESC")
-    Optional<Integer> findLatestOrderNumber();
+    @Query(value = "SELECT o.order_number FROM Order o WHERE DATE(o.order_time) = :orderTime ORDER BY o.order_number DESC")
+    Optional<Integer> findLatestOrderNumber(@Param("orderTime") LocalDate orderTime);
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
@@ -7,6 +7,8 @@ import com.study.kioskbackend.global.common.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 public class OrderService {
@@ -16,7 +18,7 @@ public class OrderService {
     public ResponseDto<Order> order(OrderRequestDto orderRequestDto) {
 
         try {
-            int orderNum = orderRepository.findLatestOrderNumber().orElse(1) + 1;
+            int orderNum = orderRepository.findLatestOrderNumber(LocalDate.now()).orElse(1) + 1;
             Order order = orderRepository.save(orderRequestDto.toEntity(orderNum));
             return ResponseDto.success(order);
         } catch (Exception e) {

--- a/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
@@ -1,0 +1,14 @@
+package com.study.kioskbackend.domain.order.service;
+
+import com.study.kioskbackend.domain.order.repository.OrderRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderService {
+
+    private final OrderRepository repository;
+}

--- a/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
@@ -1,14 +1,27 @@
 package com.study.kioskbackend.domain.order.service;
 
+import com.study.kioskbackend.domain.order.dto.OrderRequestDto;
+import com.study.kioskbackend.domain.order.entity.Order;
 import com.study.kioskbackend.domain.order.repository.OrderRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class OrderService {
 
-    private final OrderRepository repository;
+    private final OrderRepository orderRepository;
+
+    public ResponseEntity<Order> order(OrderRequestDto orderRequestDto) {
+
+        try {
+            int orderNum = orderRepository.findLatestOrderNumber().orElse(1)+1;
+            Order order = orderRepository.save(orderRequestDto.toEntity(orderNum));
+            return ResponseEntity.ok(order);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
 }

--- a/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
+++ b/src/main/java/com/study/kioskbackend/domain/order/service/OrderService.java
@@ -3,9 +3,8 @@ package com.study.kioskbackend.domain.order.service;
 import com.study.kioskbackend.domain.order.dto.OrderRequestDto;
 import com.study.kioskbackend.domain.order.entity.Order;
 import com.study.kioskbackend.domain.order.repository.OrderRepository;
+import com.study.kioskbackend.global.common.ResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,14 +13,27 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
 
-    public ResponseEntity<Order> order(OrderRequestDto orderRequestDto) {
+    public ResponseDto<Order> order(OrderRequestDto orderRequestDto) {
 
         try {
-            int orderNum = orderRepository.findLatestOrderNumber().orElse(1)+1;
+            int orderNum = orderRepository.findLatestOrderNumber().orElse(1) + 1;
             Order order = orderRepository.save(orderRequestDto.toEntity(orderNum));
-            return ResponseEntity.ok(order);
+            return ResponseDto.success(order);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+            return ResponseDto.fail("500", "주문목록 불러오기 실패");
         }
     }
+
+    public ResponseDto<Integer> getUserPoint(String userId) {
+        //User user = orderRepository.findByUserId(userId);
+        return ResponseDto.success(1234);
+    }
+
+    public ResponseDto<Void> updateUserPoint(int point) {
+        //User user = userRepository.findById(userIdx);
+        //user.setUserPoint(point);
+        return ResponseDto.successWithNoData();
+    }
+
+
 }

--- a/src/main/java/com/study/kioskbackend/global/common/OrderStatus.java
+++ b/src/main/java/com/study/kioskbackend/global/common/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.study.kioskbackend.global.common;
+
+public enum OrderStatus {
+    결제완료,
+    결제중;
+
+}


### PR DESCRIPTION
## 📢 기능 설명 
필요시 실행결과 스크린샷 첨부
<br>
<img width="494" alt="image" src="https://github.com/hanaro-kiosk/mcdonald_kiosk_backend/assets/48551119/21a3a17c-89e3-4708-ba7d-3df3cea71830">

- 사용자의 적립금을 갱신시켜주는 api (
<img width="371" alt="image" src="https://github.com/hanaro-kiosk/mcdonald_kiosk_backend/assets/48551119/98edce60-e5dc-4f35-9162-7e6fd3f1f3c6">

- 사용자의 적립금을 가져오는 api (data에 적립금이 들어옴)
<img width="521" alt="image" src="https://github.com/hanaro-kiosk/mcdonald_kiosk_backend/assets/48551119/daa08041-2703-4154-9db8-4d649df1ca4e">

- 주문목록을 저장하는 api

***참고 사항***
- 아직 user 관련 메서드는 UserRepository가 생성되면 마저 구현 할 예정입니다.

## 연결된 issue
close #3 
<br>